### PR TITLE
feat: 회원가입 및 유저 관련 API 구현 완료

### DIFF
--- a/src/main/java/com/jobfit/server/domain/user/User.java
+++ b/src/main/java/com/jobfit/server/domain/user/User.java
@@ -35,4 +35,7 @@ public class User extends BaseEntity {
 		this.status=status != null? status : UserStatus.ACTIVE;
 		this.createdAt = LocalDateTime.now();
 	}
+	public void withDraw(){
+		this.status=UserStatus.WITHDRAW;
+	}
 }

--- a/src/main/java/com/jobfit/server/infras/user/UserRepositoryImpl.java
+++ b/src/main/java/com/jobfit/server/infras/user/UserRepositoryImpl.java
@@ -29,4 +29,5 @@ public class UserRepositoryImpl implements UserRepository {
 		return userJpaRepository.existsByEmail(email);
 	}
 
+
 }

--- a/src/main/java/com/jobfit/server/interfaces/api/user/UserCheckDuplicatedEmailRequest.java
+++ b/src/main/java/com/jobfit/server/interfaces/api/user/UserCheckDuplicatedEmailRequest.java
@@ -1,0 +1,16 @@
+package com.jobfit.server.interfaces.api.user;
+
+import com.jobfit.server.service.user.UserCheckDuplicatedEmailCommand;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserCheckDuplicatedEmailRequest {
+    private String email;
+
+    public UserCheckDuplicatedEmailCommand toCommand(){
+        return new UserCheckDuplicatedEmailCommand(email);
+    }
+
+}

--- a/src/main/java/com/jobfit/server/interfaces/api/user/UserController.java
+++ b/src/main/java/com/jobfit/server/interfaces/api/user/UserController.java
@@ -1,9 +1,12 @@
 package com.jobfit.server.interfaces.api.user;
 
+import com.jobfit.server.service.user.UserCheckDuplicatedEmailCommand;
+import com.jobfit.server.service.user.UserWithDrawCommand;
+import com.jobfit.server.support.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 import com.jobfit.server.interfaces.api.ApiResponse;
 import com.jobfit.server.service.user.UserInfo;
@@ -11,14 +14,36 @@ import com.jobfit.server.service.user.UserService;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.Map;
+
 @RestController
+@RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
 public class UserController {
 
 	private final UserService userService;
 
-	@PostMapping("/api/v1/signup")
+	@PostMapping("/signup")
 	public ResponseEntity<ApiResponse<UserInfo>> signup(@RequestBody UserSignupRequest request) {
 		return ApiResponse.OK(userService.signUp(request.toCommand()));
 	}
+	@PostMapping("/checkemail")
+	public ResponseEntity<?> checkEmail(@RequestBody @Validated UserCheckDuplicatedEmailRequest request)
+	{
+		boolean exists=userService.isEmailDuplicated(request.toCommand());
+		return ApiResponse.OK(Map.of("duplicated",exists));
+	}
+	// 유저에 대한 접근은 시큐리티에 커스텀 유저로 접근해야 되기 때문에 request 불필요 ->
+	//@AuthenticationPrincipal 이걸로 인가된 사용자인지 시큐리티 자체적으로 검증해주기 대문에 커스텀 유저로 접근해서
+	// 체크해야됨
+	@PatchMapping("/withdraw")
+	public ResponseEntity<?> withDrawUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+		String email = userDetails.getUsername();
+
+		userService.withDrawUser(new UserWithDrawCommand(email));
+		return ApiResponse.OK(Map.of("message", "회원 탈퇴가 완료되었습니다."));
+	}
+
 }
+
+

--- a/src/main/java/com/jobfit/server/service/user/UserCheckDuplicatedEmailCommand.java
+++ b/src/main/java/com/jobfit/server/service/user/UserCheckDuplicatedEmailCommand.java
@@ -1,0 +1,14 @@
+package com.jobfit.server.service.user;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+
+public class UserCheckDuplicatedEmailCommand {
+    private String email;
+
+    public UserCheckDuplicatedEmailCommand(String email){
+        this.email=email;
+    }
+}

--- a/src/main/java/com/jobfit/server/service/user/UserService.java
+++ b/src/main/java/com/jobfit/server/service/user/UserService.java
@@ -22,5 +22,16 @@ public class UserService {
 		userRepository.save(user);
 		return UserInfo.from(user);
 	}
+	@Transactional
+	public boolean isEmailDuplicated(UserCheckDuplicatedEmailCommand command) {
+		return userRepository.existsByEmail(command.getEmail());
+	}
 
+	@Transactional
+	public void withDrawUser(UserWithDrawCommand command){
+		User user= userRepository.findByEmail(command.getEmail())
+				.orElseThrow(() -> new IllegalArgumentException("해당 이메일의 사용자가 존재하지 않습니다"));
+
+		user.withDraw();
+	}
 }

--- a/src/main/java/com/jobfit/server/service/user/UserWithDrawCommand.java
+++ b/src/main/java/com/jobfit/server/service/user/UserWithDrawCommand.java
@@ -1,0 +1,15 @@
+package com.jobfit.server.service.user;
+
+import com.jobfit.server.domain.user.UserStatus;
+import lombok.Getter;
+
+@Getter
+
+public class UserWithDrawCommand {
+    private final String email;
+
+    public UserWithDrawCommand(String email) {
+        this.email = email;
+    }
+}
+

--- a/src/main/java/com/jobfit/server/support/security/SecurityConfig.java
+++ b/src/main/java/com/jobfit/server/support/security/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig {
     ) {
         JwtUsernamePasswordAuthenticationFilter filter =
                 new JwtUsernamePasswordAuthenticationFilter(authenticationManager, loginSuccessHandler, loginFailureHandler);
-        filter.setFilterProcessesUrl("/api/v1/login");
+        filter.setFilterProcessesUrl("/api/v1/user/login");
         return filter;
     }
 
@@ -89,7 +89,8 @@ public class SecurityConfig {
                 // .antMatchers(HttpMethod.GET, "/api/v1/**").authenticated() 로그인한 사용자만 허가
                 // 추가안해주시면 작동안합니다 꼭추가해주세요
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/login", "/api/v1/signup", "/css/**").permitAll()
+                        .requestMatchers("/api/v1/user/login", "/api/v1/user/signup", "/api/v1/user/checkemail","api/v1/user/withdraw","/css/**").permitAll()
+                        .requestMatchers("/api/v1/user/withdraw").authenticated()
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/jobfit/server/support/security/filter/JwtUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/jobfit/server/support/security/filter/JwtUsernamePasswordAuthenticationFilter.java
@@ -27,7 +27,7 @@ public class JwtUsernamePasswordAuthenticationFilter extends UsernamePasswordAut
         super(authenticationManager);
 
         // 로그인 URL 지정
-        setFilterProcessesUrl("/api/v1/login");
+        setFilterProcessesUrl("/api/v1/user/login");
 
         // 로그인 성공/실패 핸들러 등록
         setAuthenticationSuccessHandler(loginSuccessHandler);


### PR DESCRIPTION


## ✨ 개요
회원가입 기능 개발을 마무리하고, 아래와 같은 유저 관련 기능들을 추가로 구현했습니다:

- 이메일 중복 확인 API (`/api/v1/user/checkemail`) 구현
  - 해당 이메일의 존재 여부를 Boolean 값으로 반환
- 회원 탈퇴 API (`/api/v1/user/withdraw`) 구현
  - JWT 인증 기반으로 로그인된 사용자의 상태를 `WITHDRAW`로 변경
  - 별도 요청 파라미터 없이 `@AuthenticationPrincipal`을 통해 사용자 정보 추출 → 인증 정보는 보안상 서버에서 처리하는 것이 더 안전하고 일관성 있는 방식이기 때문에, 별도의 request body 없이 처리하도록 구현
- 회원가입 요청 시 비밀번호와 확인값의 일치 여부 검증 로직 추가
- JWT 로그인 성공 시 토큰을 포함한 응답 형태 정리 및 테스트 완료

추가로 Postman을 통해 전체 플로우(JWT 로그인, 인증, 탈퇴 등) 테스트 완료하였습니다.

## ✅ 작업 내용
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 수정

---

## 🧪 테스트 내용
<!-- 어떤 테스트를 했는지 간략하게 작성해주세요 -->

---

## 📎 관련 이슈
<!-- ex: Closes #23, Fixes #45 -->

---

## 📝 기타 참고 사항
만약 로그인 테스트를 할거면 postman 헤더 부분에
KEY : Authorization
Value : Bearer (로그인할떄 뜨는 access 토큰 부분을 복사해서 넣는다)
이후에 인증인가 처리는 시큐리티 내부에서 해줌
유의 해주시기 바랍니다!